### PR TITLE
Expanded systemd api

### DIFF
--- a/src/manager/proxy.rs
+++ b/src/manager/proxy.rs
@@ -13,6 +13,9 @@ trait SystemdManager {
     fn restart_unit(&self, name: &str, mode: &str) -> zbus::Result<zvariant::OwnedObjectPath>;
     fn start_unit(&self, name: &str, mode: &str) -> zbus::Result<zvariant::OwnedObjectPath>;
     fn stop_unit(&self, name: &str, mode: &str) -> zbus::Result<zvariant::OwnedObjectPath>;
+    fn enable_unit_files(&self, files: &[&str], runtime: bool, force: bool) -> zbus::Result<(bool, Vec<(String, String, String)>)>;
+    fn disable_unit_files(&self, files: &[&str], runtime: bool) -> zbus::Result<Vec<(String, String, String)>>;
+    fn get_unit_file_state(&self, arg_1: &str) -> zbus::Result<String>;
     #[dbus_proxy(property)]
     fn architecture(&self) -> zbus::Result<String>;
     #[dbus_proxy(property)]

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -4,13 +4,15 @@ use std::fmt::Display;
 pub struct UnitConfiguration<'a> {
     pub description: &'a str,
     pub after: Vec<&'a str>,
+    pub wants: Vec<&'a str>,
 }
 
 impl<'a> Display for UnitConfiguration<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "[Unit]")?;
         writeln!(f, "Description={}", self.description)?;
-        writeln!(f, "After={}", self.after.join(" "))
+        writeln!(f, "After={}", self.after.join(" "))?;
+        writeln!(f, "Wants={}", self.wants.join(" "))
     }
 }
 
@@ -24,6 +26,7 @@ impl<'a> UnitConfiguration<'a> {
 pub struct UnitConfigurationBuilder<'a> {
     pub description: &'a str,
     pub after: Vec<&'a str>,
+    pub wants: Vec<&'a str>,
 }
 
 impl<'a> UnitConfigurationBuilder<'a> {
@@ -37,10 +40,16 @@ impl<'a> UnitConfigurationBuilder<'a> {
         self
     }
 
+    pub fn wants(mut self, wants: &'a str) -> Self {
+        self.wants.push(wants);
+        self
+    }
+
     pub fn build(self) -> UnitConfiguration<'a> {
         let description = self.description;
         let after = self.after;
-        UnitConfiguration { description, after }
+        let wants = self.wants;
+        UnitConfiguration { description, after, wants }
     }
 }
 


### PR DESCRIPTION
Thanks for a neat crate covering some of the core needs of systemd functionality.

This PR does makes two small changes:
1. Add three new methods to the `proxy.rs` file, `enable` `disable` and `get_unit_file_state`
2. Adds the wants field to unit file, which makes specifying dependencies such as `network` possible when creating unit files.

I used the `zbus_xmlgen` tool https://crates.io/crates/zbus_xmlgen to get the method signatures, so thanks to zeenix for that.