### PR TITLE
Updated zbus dependency to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["systemd", "zbus"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zbus = { version = "2.0.1" }
+zbus = { version = "3.14" }
 zvariant = "3.0.0"
 thiserror = "1.0.29"
 tracing = "0.1"


### PR DESCRIPTION
On an embedded Debian 11 system I've been getting messages similar to the following:

```
 Error(ZBus(Variant(Message("invalid value: string \"()\", expected at least one field signature between `(` and `)`"))))'
```

This pull request updates the `zbus` dependency to latest which makes the error go away